### PR TITLE
fix: respect local timezone for scheduler

### DIFF
--- a/server/internal/scheduler/service.go
+++ b/server/internal/scheduler/service.go
@@ -45,7 +45,7 @@ type Service struct {
 func NewService(tasks repository.BackupTaskRepository, runner TaskRunner, logger *zap.Logger) *Service {
 	parser := cron.NewParser(cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
 	return &Service{
-		cron:          cron.New(cron.WithParser(parser), cron.WithLocation(time.UTC)),
+		cron:          cron.New(cron.WithParser(parser), cron.WithLocation(time.Local)),
 		tasks:         tasks,
 		runner:        runner,
 		logger:        logger,

--- a/server/internal/scheduler/service_test.go
+++ b/server/internal/scheduler/service_test.go
@@ -68,3 +68,37 @@ func TestServiceSyncTaskAndTrigger(t *testing.T) {
 		t.Fatalf("expected scheduled runner to be triggered")
 	}
 }
+
+func TestServiceSchedulesTasksInLocalTimezone(t *testing.T) {
+	location, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("LoadLocation returned error: %v", err)
+	}
+	originalLocal := time.Local
+	time.Local = location
+	t.Cleanup(func() {
+		time.Local = originalLocal
+	})
+
+	service := NewService(&fakeTaskRepository{}, &fakeRunner{}, nil)
+	if got := service.cron.Location(); got != location {
+		t.Fatalf("cron location = %v, want %v", got, location)
+	}
+
+	task := &model.BackupTask{ID: 1, Enabled: true, CronExpr: "0 5 * * *"}
+	if err := service.SyncTask(context.Background(), task); err != nil {
+		t.Fatalf("SyncTask returned error: %v", err)
+	}
+	entryID, ok := service.entries[task.ID]
+	if !ok {
+		t.Fatalf("expected cron entry for task %d", task.ID)
+	}
+
+	entry := service.cron.Entry(entryID)
+	now := time.Date(2026, 4, 30, 4, 0, 0, 0, location)
+	got := entry.Schedule.Next(now)
+	want := time.Date(2026, 4, 30, 5, 0, 0, 0, location)
+	if !got.Equal(want) {
+		t.Fatalf("next run = %s, want %s", got, want)
+	}
+}


### PR DESCRIPTION
Summary: Use the process local timezone for backup and verification cron schedules, and add Asia/Shanghai regression coverage for issue #53. Tests: go test ./... . Fixes #53