### PR TITLE
feat(verify): 验证流程同样比对备份 SHA-256，对齐恢复路径强度

### DIFF
--- a/server/internal/service/verification_service.go
+++ b/server/internal/service/verification_service.go
@@ -316,14 +316,26 @@ func (s *VerificationService) executeLocally(ctx context.Context, verID uint, ta
 		logger.Errorf("写入沙箱失败：%v", err)
 		return
 	}
+	// 完整性校验：先比对下载对象的 SHA-256（外层对象，与备份记录一致），再做结构校验。
+	// 与恢复路径保持一致的强度；早期无 checksum 的备份跳过（向后兼容）。
+	if backupRecord.Checksum != "" {
+		logger.Infof("校验备份完整性（SHA-256）")
+		if csErr := verifyArtifactChecksum(artifactPath, backupRecord.Checksum); csErr != nil {
+			errMessage = csErr.Error()
+			summary = "完整性校验失败"
+			logger.Errorf("完整性校验失败：%v", csErr)
+			return
+		}
+		logger.Infof("完整性校验通过")
+	}
 	preparedPath, err := s.prepareArtifact(artifactPath, logger)
 	if err != nil {
 		errMessage = err.Error()
 		logger.Errorf("准备归档失败：%v", err)
 		return
 	}
-	// 按任务类型分派校验
-	report, verifyErr := s.verifyByType(task.Type, preparedPath, backupRecord.Checksum, logger)
+	// 按任务类型做结构校验（外层 SHA-256 已在上方单独校验）。
+	report, verifyErr := s.verifyByType(task.Type, preparedPath, logger)
 	if verifyErr != nil {
 		errMessage = verifyErr.Error()
 		if report != nil && report.Detail != "" {
@@ -344,8 +356,8 @@ func (s *VerificationService) prepareArtifact(artifactPath string, logger *backu
 	return prepareBackupArtifact(s.cipher, artifactPath, logger)
 }
 
-// verifyByType 按任务类型分派到对应 Verify* 策略。
-func (s *VerificationService) verifyByType(taskType, artifactPath, checksum string, logger *backup.ExecutionLogger) (*backup.VerifyReport, error) {
+// verifyByType 按任务类型分派到对应 Verify* 结构校验策略（不含 SHA-256 比对）。
+func (s *VerificationService) verifyByType(taskType, artifactPath string, logger *backup.ExecutionLogger) (*backup.VerifyReport, error) {
 	switch strings.ToLower(strings.TrimSpace(taskType)) {
 	case "file":
 		logger.Infof("执行文件归档校验")


### PR DESCRIPTION
## 背景

验证（verify）路径此前**只做归档结构校验，从不比对存储对象的 SHA-256**——`backupRecord.Checksum` 被传入 `verifyByType`，但该函数对 `file` 类型以**空串**调用 `VerifyTarArchive`，checksum 形参实际从未生效。结果：验证的完整性强度弱于刚加固的恢复路径（#75/#76），无法发现字节级损坏/篡改。

## 改动

- `VerificationService.executeLocally` 在解压前比对**下载对象**的 SHA-256（复用 #75 的 `verifyArtifactChecksum`），不匹配即判定验证失败。
- 移除 `verifyByType` 已失效的 `checksum` 形参，使「外层 SHA-256 校验」与「内层结构校验」职责清晰分离。

## 测试

- 复用已单元测试的 `verifyArtifactChecksum`（#75）；接线方式与集成测试覆盖的恢复路径完全一致。
- `go build ./...` 与 `go test ./...` 全绿。

至此 **备份 / 恢复 / 验证** 三条路径的完整性校验保持一致。