### PR TITLE
fix(security): 节点文件浏览限制为非 viewer

### DIFF
--- a/server/internal/http/router.go
+++ b/server/internal/http/router.go
@@ -292,7 +292,10 @@ func NewRouter(deps RouterDependencies) *gin.Engine {
 		nodes.POST("", RequireRole("admin"), nodeHandler.Create)
 		nodes.PUT("/:id", RequireRole("admin"), nodeHandler.Update)
 		nodes.DELETE("/:id", RequireRole("admin"), nodeHandler.Delete)
-		nodes.GET("/:id/fs/list", nodeHandler.ListDirectory)
+		// 文件浏览会枚举节点文件系统目录（含 /etc、/root 等），属敏感读操作：
+		// 限制为非 viewer（admin/operator），与"创建备份任务需选源路径"的权限对齐，
+		// 避免只读 viewer 借此探查服务器目录结构。
+		nodes.GET("/:id/fs/list", RequireNotViewer(), nodeHandler.ListDirectory)
 		nodes.POST("/batch", RequireRole("admin"), nodeHandler.BatchCreate)
 		nodes.POST("/:id/install-tokens", RequireRole("admin"), nodeHandler.CreateInstallToken)
 		nodes.POST("/:id/rotate-token", RequireRole("admin"), nodeHandler.RotateToken)


### PR DESCRIPTION
## 问题

`GET /api/nodes/:id/fs/list`（节点文件浏览）此前仅校验登录态、**无角色限制**——只读 **viewer** 也能枚举节点文件系统目录（含 `/etc`、`/root`、`/home` 等），属信息泄露。其余节点写操作（创建/更新/删除/批量/令牌）均已要求 `admin`，唯独这个敏感读操作无守卫。

## 改动

为该路由加 `RequireNotViewer()`（= `admin`/`operator`）守卫，与"创建备份任务需选源路径"的权限级别对齐——操作员配置任务时需要文件浏览，只读 viewer 不参与任务配置，无需该能力。

## 测试

- `RequireNotViewer()` 中间件已在 storage-targets / backup-tasks / notifications 等约 15 处路由使用，行为成熟；本 PR 仅为该路由套用同一守卫。
- `go build ./...` 与 `go test ./...` 全绿。