### PR TITLE
feat(backup): 新增备份内容浏览

### DIFF
--- a/server/internal/http/backup_record_handler.go
+++ b/server/internal/http/backup_record_handler.go
@@ -52,6 +52,20 @@ func (h *BackupRecordHandler) Get(c *gin.Context) {
 	response.Success(c, item)
 }
 
+// Contents 返回备份记录的文件清单（内容浏览，只读）。
+func (h *BackupRecordHandler) Contents(c *gin.Context) {
+	id, ok := parseUintParam(c, "id")
+	if !ok {
+		return
+	}
+	contents, err := h.service.ListContents(c.Request.Context(), id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.Success(c, contents)
+}
+
 func (h *BackupRecordHandler) StreamLogs(c *gin.Context) {
 	id, ok := parseUintParam(c, "id")
 	if !ok {

--- a/server/internal/http/router.go
+++ b/server/internal/http/router.go
@@ -167,6 +167,7 @@ func NewRouter(deps RouterDependencies) *gin.Engine {
 		backupRecords.GET("/:id", backupRecordHandler.Get)
 		backupRecords.GET("/:id/logs/stream", backupRecordHandler.StreamLogs)
 		backupRecords.GET("/:id/download", backupRecordHandler.Download)
+		backupRecords.GET("/:id/contents", backupRecordHandler.Contents)
 		backupRecords.POST("/:id/restore", RequireNotViewer(), backupRecordHandler.Restore)
 		backupRecords.POST("/batch-delete", RequireNotViewer(), backupRecordHandler.BatchDelete)
 		backupRecords.DELETE("/:id", RequireNotViewer(), backupRecordHandler.Delete)

--- a/server/internal/service/backup_record_service.go
+++ b/server/internal/service/backup_record_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"sort"
 	"strings"
 	"time"
 
@@ -78,6 +79,64 @@ func (s *BackupRecordService) Get(ctx context.Context, id uint) (*BackupRecordDe
 		return nil, apperror.New(404, "BACKUP_RECORD_NOT_FOUND", "备份记录不存在", err)
 	}
 	return toBackupRecordDetail(item, s.logHub), nil
+}
+
+// BackupContentEntry 描述备份内单个条目（文件或目录），用于内容浏览。
+type BackupContentEntry struct {
+	Path  string `json:"path"`
+	Size  int64  `json:"size"`
+	IsDir bool   `json:"isDir"`
+}
+
+// BackupRecordContents 是一次备份的内容清单视图。
+type BackupRecordContents struct {
+	RecordID    uint                 `json:"recordId"`
+	Total       int                  `json:"total"`
+	Truncated   bool                 `json:"truncated"`
+	BasedOnFull uint                 `json:"basedOnFull,omitempty"` // 差异记录时，清单取自该基线全量
+	Entries     []BackupContentEntry `json:"entries"`
+}
+
+const backupContentsMaxEntries = 10000
+
+// ListContents 返回某备份记录的文件清单（仅文件类型的新全量备份会记录清单）。
+// 差异记录回退到其基线全量的清单，近似展示恢复后的目录结构。无清单时返回明确错误。
+func (s *BackupRecordService) ListContents(ctx context.Context, id uint) (*BackupRecordContents, error) {
+	item, err := s.records.FindByID(ctx, id)
+	if err != nil {
+		return nil, apperror.Internal("BACKUP_RECORD_GET_FAILED", "无法获取备份记录", err)
+	}
+	if item == nil {
+		return nil, apperror.New(404, "BACKUP_RECORD_NOT_FOUND", "备份记录不存在", nil)
+	}
+	manifestJSON := item.Manifest
+	basedOnFull := uint(0)
+	if strings.TrimSpace(manifestJSON) == "" && item.BaseRecordID != 0 {
+		if base, baseErr := s.records.FindByID(ctx, item.BaseRecordID); baseErr == nil && base != nil {
+			manifestJSON = base.Manifest
+			basedOnFull = base.ID
+		}
+	}
+	if strings.TrimSpace(manifestJSON) == "" {
+		return nil, apperror.New(422, "BACKUP_CONTENTS_UNAVAILABLE", "该备份未记录文件清单（仅文件类型的新全量备份支持内容浏览），请重新执行一次全量备份后再试。", nil)
+	}
+	manifest, decErr := backup.DecodeManifest([]byte(manifestJSON))
+	if decErr != nil {
+		return nil, apperror.Internal("BACKUP_CONTENTS_DECODE_FAILED", "解析备份清单失败", decErr)
+	}
+	entries := manifest.Entries
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
+	total := len(entries)
+	truncated := false
+	if total > backupContentsMaxEntries {
+		entries = entries[:backupContentsMaxEntries]
+		truncated = true
+	}
+	result := &BackupRecordContents{RecordID: item.ID, Total: total, Truncated: truncated, BasedOnFull: basedOnFull, Entries: make([]BackupContentEntry, 0, len(entries))}
+	for _, e := range entries {
+		result.Entries = append(result.Entries, BackupContentEntry{Path: e.Path, Size: e.Size, IsDir: e.IsDir})
+	}
+	return result, nil
 }
 
 func (s *BackupRecordService) SubscribeLogs(ctx context.Context, id uint, buffer int) (<-chan backup.LogEvent, func(), error) {

--- a/web/src/components/backup-records/BackupRecordContentsModal.tsx
+++ b/web/src/components/backup-records/BackupRecordContentsModal.tsx
@@ -1,0 +1,109 @@
+import { Alert, Input, Modal, Spin, Table, Tag, Typography } from '@arco-design/web-react'
+import { useEffect, useMemo, useState } from 'react'
+import { getBackupRecordContents } from '../../services/backup-records'
+import type { BackupRecordContentEntry, BackupRecordContents } from '../../types/backup-records'
+import { resolveErrorMessage } from '../../utils/error'
+import { formatBytes } from '../../utils/format'
+
+interface BackupRecordContentsModalProps {
+  visible: boolean
+  recordId?: number
+  onClose: () => void
+}
+
+// BackupRecordContentsModal 浏览某次备份捕获的文件清单（只读）。
+// 数据来源于全量备份记录的清单，无需下载归档，秒级展示并支持按路径筛选。
+export function BackupRecordContentsModal({ visible, recordId, onClose }: BackupRecordContentsModalProps) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [contents, setContents] = useState<BackupRecordContents | null>(null)
+  const [keyword, setKeyword] = useState('')
+
+  useEffect(() => {
+    if (!visible || !recordId) {
+      return
+    }
+    let active = true
+    setLoading(true)
+    setError('')
+    setKeyword('')
+    setContents(null)
+    void (async () => {
+      try {
+        const data = await getBackupRecordContents(recordId)
+        if (active) {
+          setContents(data)
+        }
+      } catch (e) {
+        if (active) {
+          setError(resolveErrorMessage(e, '加载备份内容失败'))
+        }
+      } finally {
+        if (active) {
+          setLoading(false)
+        }
+      }
+    })()
+    return () => {
+      active = false
+    }
+  }, [visible, recordId])
+
+  const filtered = useMemo(() => {
+    const entries = contents?.entries ?? []
+    const kw = keyword.trim().toLowerCase()
+    if (!kw) {
+      return entries
+    }
+    return entries.filter((e) => e.path.toLowerCase().includes(kw))
+  }, [contents, keyword])
+
+  return (
+    <Modal visible={visible} title="备份内容" footer={null} onCancel={onClose} unmountOnExit style={{ width: 760 }}>
+      {loading ? (
+        <Spin style={{ display: 'block', textAlign: 'center', padding: 40 }} />
+      ) : error ? (
+        <Alert type="warning" content={error} />
+      ) : contents ? (
+        <div>
+          <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+            共 {contents.total} 个条目
+            {contents.truncated ? `（清单较大，仅展示前 ${contents.entries.length} 个）` : ''}
+            {contents.basedOnFull ? `；差异备份，清单取自基线全量 #${contents.basedOnFull}` : ''}
+          </Typography.Text>
+          <Input.Search allowClear placeholder="按路径筛选" value={keyword} onChange={setKeyword} style={{ margin: '8px 0' }} />
+          <Table
+            size="small"
+            rowKey="path"
+            data={filtered}
+            pagination={{ pageSize: 50, sizeCanChange: false }}
+            scroll={{ y: 420 }}
+            columns={[
+              {
+                title: '路径',
+                dataIndex: 'path',
+                render: (_: unknown, row: BackupRecordContentEntry) => (
+                  <span>
+                    {row.isDir ? (
+                      <Tag size="small" color="arcoblue">
+                        目录
+                      </Tag>
+                    ) : null}{' '}
+                    {row.path}
+                  </span>
+                ),
+              },
+              {
+                title: '大小',
+                dataIndex: 'size',
+                width: 120,
+                align: 'right',
+                render: (_: unknown, row: BackupRecordContentEntry) => (row.isDir ? '-' : formatBytes(row.size)),
+              },
+            ]}
+          />
+        </div>
+      ) : null}
+    </Modal>
+  )
+}

--- a/web/src/components/backup-records/BackupRecordLogDrawer.tsx
+++ b/web/src/components/backup-records/BackupRecordLogDrawer.tsx
@@ -12,6 +12,7 @@ import type { BackupTaskDetail } from '../../types/backup-tasks'
 import { resolveErrorMessage } from '../../utils/error'
 import { formatBytes, formatDateTime, formatDuration } from '../../utils/format'
 import { RestoreConfirmModal } from '../restore-records/RestoreConfirmModal'
+import { BackupRecordContentsModal } from './BackupRecordContentsModal'
 
 interface BackupRecordLogDrawerProps {
   visible: boolean
@@ -53,6 +54,7 @@ export function BackupRecordLogDrawer({ visible, recordId, onCancel, onChanged }
   const [restoreLoading, setRestoreLoading] = useState(false)
   const [restorePreparing, setRestorePreparing] = useState(false)
   const [verifyLoading, setVerifyLoading] = useState(false)
+  const [contentsVisible, setContentsVisible] = useState(false)
 
   useEffect(() => {
     if (!visible || !recordId) {
@@ -268,6 +270,7 @@ export function BackupRecordLogDrawer({ visible, recordId, onCancel, onChanged }
             <Button loading={acting} onClick={handleDownload}>
               下载
             </Button>
+            <Button onClick={() => setContentsVisible(true)}>查看内容</Button>
             {writable && (
               <Button
                 type="primary"
@@ -324,6 +327,7 @@ export function BackupRecordLogDrawer({ visible, recordId, onCancel, onChanged }
         }}
         onConfirm={() => void handleConfirmRestore()}
       />
+      <BackupRecordContentsModal visible={contentsVisible} recordId={recordId} onClose={() => setContentsVisible(false)} />
     </Drawer>
   )
 }

--- a/web/src/services/backup-records.ts
+++ b/web/src/services/backup-records.ts
@@ -1,5 +1,5 @@
 import { http, getAccessToken, type ApiEnvelope, unwrapApiEnvelope } from './http'
-import type { BackupLogEvent, BackupRecordDetail, BackupRecordListFilter, BackupRecordSummary } from '../types/backup-records'
+import type { BackupLogEvent, BackupRecordContents, BackupRecordDetail, BackupRecordListFilter, BackupRecordSummary } from '../types/backup-records'
 import { resolveErrorMessage } from '../utils/error'
 
 interface RecordLogStreamHandlers {
@@ -66,6 +66,12 @@ export async function listBackupRecords(filter: BackupRecordListFilter = {}) {
 
 export async function getBackupRecord(id: number) {
   const response = await http.get<ApiEnvelope<BackupRecordDetail>>(`/backup/records/${id}`)
+  return unwrapApiEnvelope(response.data)
+}
+
+// getBackupRecordContents 获取备份记录的文件清单（内容浏览，只读）。
+export async function getBackupRecordContents(id: number) {
+  const response = await http.get<ApiEnvelope<BackupRecordContents>>(`/backup/records/${id}/contents`)
   return unwrapApiEnvelope(response.data)
 }
 

--- a/web/src/types/backup-records.ts
+++ b/web/src/types/backup-records.ts
@@ -29,6 +29,20 @@ export interface BackupRecordSummary {
   backupKind: 'full' | 'differential'
 }
 
+export interface BackupRecordContentEntry {
+  path: string
+  size: number
+  isDir: boolean
+}
+
+export interface BackupRecordContents {
+  recordId: number
+  total: number
+  truncated: boolean
+  basedOnFull?: number
+  entries: BackupRecordContentEntry[]
+}
+
 export interface StorageUploadResultItem {
   storageTargetId: number
   storageTargetName: string


### PR DESCRIPTION
## 背景
此前只能整体下载或恢复一个备份，**无法查看里面到底有哪些文件**。运维常需核对「昨晚的备份是否真的包含 /etc/nginx」「某目录是否被排除规则误伤」，却没有手段——只能盲信。本 PR 补齐「浏览备份内容」这一基础能力。

## 实现（零额外开销）
直接复用差异备份新增的**清单**机制——所有文件类型的新全量备份都会记录条目清单（路径/大小/目录），因此浏览**无需下载或解压归档**，秒级返回。

- **`BackupRecordService.ListContents`**：解析记录清单为内容视图；差异记录回退到其**基线全量**清单（近似展示恢复后结构）；超 1 万条标记截断；无清单（老备份/数据库类型）时返回明确提示。
- **`GET /backup/records/:id/contents`**：只读，viewer 角色亦可访问。
- **前端**：备份记录详情新增「查看内容」按钮，弹窗以**可按路径筛选**的表格展示文件与大小。

## 安全
只读、零文件系统写入；路径仅用于展示与前端筛选，不参与任何文件操作 → 无路径穿越/注入面。

## 测试
- `go test ./internal/service ./internal/http` 通过；`tsc --noEmit` 通过

## 说明
- 仅文件类型的**新**全量备份记录清单（本能力上线后产生的备份）；更早的备份会提示「重新执行一次全量备份后可浏览」。
- 这是「选择性恢复（按需恢复单个文件）」的基础，后续可在此之上增加勾选恢复。