### PR TITLE
chore(ci): 为工作流声明最小权限 (contents: read)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, master]
 
+# 最小权限：构建/测试仅需读取仓库内容，显式声明以收敛默认的可写令牌。
+permissions:
+  contents: read
+
 jobs:
   backend:
     name: Go Build & Test


### PR DESCRIPTION
## 背景

修复仓库 CodeQL 的两处 `actions/missing-workflow-permissions` 告警（`.github/workflows/ci.yml:11`、`:31`）：工作流未显式声明 `permissions`，`GITHUB_TOKEN` 默认携带可写权限。

## 改动

在 `ci.yml` 顶层声明最小权限 `permissions: contents: read`——构建/测试 job 仅需检出与读取仓库内容，无需写权限。

## 影响

纯 CI 配置加固，不影响构建/测试逻辑；同时清掉本仓库剩余的两个未决 CodeQL 告警（其余 6 个已按误报/设计预期完成三态化）。